### PR TITLE
IOPS and throughput configuration for volumes

### DIFF
--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -90,6 +90,8 @@ resource "aws_launch_configuration" "launch_configuration" {
   root_block_device {
     volume_type           = var.root_volume_type
     volume_size           = var.root_volume_size
+    iops                  = var.root_volume_iops
+    throughput            = var.root_volume_throughput
     delete_on_termination = var.root_volume_delete_on_termination
   }
 
@@ -101,6 +103,7 @@ resource "aws_launch_configuration" "launch_configuration" {
       volume_size           = ebs_block_device.value["volume_size"]
       snapshot_id           = lookup(ebs_block_device.value, "snapshot_id", null)
       iops                  = lookup(ebs_block_device.value, "iops", null)
+      throughput            = lookup(ebs_block_device.value, "throughput", null)
       encrypted             = lookup(ebs_block_device.value, "encrypted", null)
       delete_on_termination = lookup(ebs_block_device.value, "delete_on_termination", null)
     }

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -131,6 +131,18 @@ variable "root_volume_size" {
   default     = 50
 }
 
+variable "root_volume_iops" {
+  description = "IOPS to provision, only set when volume type is set to gp3 or io2."
+  type        = number
+  default     = null
+}
+
+variable "root_volume_throughput" {
+  description = "Throughput to provision, only set when type is set to gp3."
+  type        = number
+  default     = null
+}
+
 variable "root_volume_delete_on_termination" {
   description = "Whether the volume should be destroyed on instance termination."
   default     = true


### PR DESCRIPTION
Alight IOPS and throughput configuration so that both of these can be set for root and extra volumes.