### PR TITLE
Amazon Linux 2023 and Ubuntu 24.04 support

### DIFF
--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -69,6 +69,21 @@ function assert_not_empty {
   fi
 }
 
+function install_aws_cli {
+  log_info "Installing AWS CLI"
+
+  cpu_arch="$(uname -m)"
+  local readonly url="https://awscli.amazonaws.com/awscli-exe-linux-${cpu_arch}.zip"
+  local readonly download_path="/tmp/awscliv2.zip"
+
+  unzip -d /tmp "$download_path"
+  sudo /tmp/aws/install
+}
+
+function has_dnf {
+  [ -n "$(command -v dnf)" ]
+}
+
 function has_yum {
   [ -n "$(command -v yum)" ]
 }
@@ -82,14 +97,19 @@ function install_dependencies {
 
   if $(has_apt_get); then
     sudo apt-get update -y
-    sudo apt-get install -y awscli curl unzip jq
+    sudo apt-get install -y curl unzip jq
+  elif $(has_dnf); then
+    sudo dnf update -y
+    sudo dnf install -y curl-minimal unzip jq
   elif $(has_yum); then
     sudo yum update -y
-    sudo yum install -y aws curl unzip jq
+    sudo yum install -y curl unzip jq
   else
     log_error "Could not find apt-get or yum. Cannot install dependencies on this OS."
     exit 1
   fi
+
+  install_aws_cli
 }
 
 function user_exists {

--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -75,7 +75,7 @@ function install_aws_cli {
   cpu_arch="$(uname -m)"
   local readonly url="https://awscli.amazonaws.com/awscli-exe-linux-${cpu_arch}.zip"
   local readonly download_path="/tmp/awscliv2.zip"
-
+  curl -o "$download_path" "$url"
   unzip -d /tmp "$download_path"
   sudo /tmp/aws/install
 }

--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -78,6 +78,7 @@ function install_aws_cli {
   curl -o "$download_path" "$url"
   unzip -d /tmp "$download_path"
   sudo /tmp/aws/install
+  rm -rf /tmp/aws
 }
 
 function has_dnf {

--- a/modules/install-nomad/install-nomad
+++ b/modules/install-nomad/install-nomad
@@ -79,6 +79,7 @@ function install_aws_cli {
   unzip -d /tmp "$download_path"
   sudo /tmp/aws/install
   rm -rf /tmp/aws
+  rm -f "$download_path"
 }
 
 function has_dnf {


### PR DESCRIPTION
Add support for Amazon Linux 2023 and Ubuntu 24.04.

* Using `dnf` as a proxy to checking if OS is Amazon Linux 2023 - this might not be the best approach an might need to be improved in the future
* Not tested for backwards compatibility