### PR TITLE
Migrate launch configuration to launch template

### DIFF
--- a/examples/nomad-consul-separate-cluster/outputs.tf
+++ b/examples/nomad-consul-separate-cluster/outputs.tf
@@ -6,8 +6,8 @@ output "asg_name_nomad_servers" {
   value = module.nomad_servers.asg_name
 }
 
-output "launch_config_name_nomad_servers" {
-  value = module.nomad_servers.launch_config_name
+output "launch_template_name_nomad_servers" {
+  value = module.nomad_servers.launch_template_name
 }
 
 output "iam_role_arn_nomad_servers" {

--- a/modules/nomad-cluster/README.md
+++ b/modules/nomad-cluster/README.md
@@ -178,7 +178,7 @@ If you want to deploy a new version of Nomad across the cluster, the best way to
 1. Set the `ami_id` parameter to the ID of the new AMI.
 1. Run `terraform apply`.
 
-This updates the Launch Configuration of the ASG, so any new Instances in the ASG will have your new AMI, but it does
+This updates the Launch Template of the ASG, so any new Instances in the ASG will have your new AMI, but it does
 NOT actually deploy those new instances. To make that happen, you should do the following:
 
 1. Issue an API call to one of the old Instances in the ASG to have it leave gracefully. E.g.:

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -84,17 +84,17 @@ resource "aws_launch_template" "launch_template" {
 
   key_name = var.ssh_key_name
 
-  vpc_security_group_ids = concat(
-    [aws_security_group.lc_security_group.id],
-    var.security_groups,
-  )
-
   placement {
     tenancy = var.tenancy
   }
 
   network_interfaces {
     associate_public_ip_address = var.associate_public_ip_address
+
+    security_groups = concat(
+      [aws_security_group.lc_security_group.id],
+      var.security_groups,
+    )
   }
 
   ebs_optimized = var.root_volume_ebs_optimized

--- a/modules/nomad-cluster/main.tf
+++ b/modules/nomad-cluster/main.tf
@@ -100,7 +100,7 @@ resource "aws_launch_template" "launch_template" {
   ebs_optimized = var.root_volume_ebs_optimized
 
   block_device_mappings {
-    device_name = "/dev/xvda"
+    device_name = var.root_volume_device_name
 
     ebs {
       volume_type           = var.root_volume_type

--- a/modules/nomad-cluster/outputs.tf
+++ b/modules/nomad-cluster/outputs.tf
@@ -14,8 +14,8 @@ output "cluster_size" {
   value = aws_autoscaling_group.autoscaling_group.desired_capacity
 }
 
-output "launch_config_name" {
-  value = aws_launch_configuration.launch_configuration.name
+output "launch_template_name" {
+  value = aws_launch_template.launch_template.name
 }
 
 output "iam_instance_profile_arn" {

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -221,7 +221,7 @@ variable "tags" {
 }
 
 variable "ebs_block_devices" {
-  description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch-configuration. Each element in the list is a map containing keys defined for ebs_block_device (see: https://www.terraform.io/docs/providers/aws/r/launch_configuration.html#ebs_block_device."
+  description = "List of ebs volume definitions for those ebs_volumes that should be added to the instances created with the EC2 launch template. Each element in the list is a map containing keys defined for block_device_mappings.ebs (see: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#block-devices."
   # We can't narrow the type down more than "any" because if we use list(object(...)), then all the fields in the
   # object will be required (whereas some, such as encrypted, should be optional), and if we use list(map(...)), all
   # the values in the map must be of the same type, whereas we need some to be strings, some to be bools, and some to

--- a/modules/nomad-cluster/variables.tf
+++ b/modules/nomad-cluster/variables.tf
@@ -119,6 +119,12 @@ variable "root_volume_ebs_optimized" {
   default     = false
 }
 
+variable "root_volume_device_name" {
+  description = "The device name to use for the root EBS volume."
+  type        = string
+  default     = "/dev/xvda"
+}
+
 variable "root_volume_type" {
   description = "The type of volume. Must be one of: standard, gp2, or io1."
   type        = string

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,8 +6,8 @@ output "asg_name_servers" {
   value = module.servers.asg_name
 }
 
-output "launch_config_name_servers" {
-  value = module.servers.launch_config_name
+output "launch_template_name_servers" {
+  value = module.servers.launch_template_name
 }
 
 output "iam_role_arn_servers" {
@@ -30,8 +30,8 @@ output "asg_name_clients" {
   value = module.clients.asg_name
 }
 
-output "launch_config_name_clients" {
-  value = module.clients.launch_config_name
+output "launch_template_name_clients" {
+  value = module.clients.launch_template_name
 }
 
 output "iam_role_arn_clients" {


### PR DESCRIPTION
* launch configurations are not deprecated, converted to launch templates
* added root_volume_device_name option to allow for OS's that don't use the /dev/xvda device name